### PR TITLE
determine 'blender' location by environment variable 'PATH'

### DIFF
--- a/src/dvs_simulator_py/render_dataset.py
+++ b/src/dvs_simulator_py/render_dataset.py
@@ -11,7 +11,7 @@ if __name__ == '__main__':
     rospy.init_node('render_dataset_node', anonymous=True)
     rospack = rospkg.RosPack()
     
-    blender_path = '/usr/bin/blender'
+    blender_path = 'blender'
     workspace_dir = rospack.get_path('dvs_simulator_py')
     dataset_dir = os.path.join(workspace_dir, 'datasets')
     dataset_name = rospy.get_param('dataset_name', 'untitled')


### PR DESCRIPTION
Do not use the full blender path, since a user might want to use another blender installation from `PATH`.